### PR TITLE
Add codeclimate file to exclude examples folder

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,0 +1,2 @@
+- exclude_patterns:
+  - "examples/"


### PR DESCRIPTION
## Add codeclimate file to exclude examples folder

#### Description
CodeClimate was detecting maintainability issues in the repo because of duplicated code between the examples